### PR TITLE
skip serializer when in config

### DIFF
--- a/bindgen-bootstrap/src/gen_kotlin_multiplatform/mod.rs
+++ b/bindgen-bootstrap/src/gen_kotlin_multiplatform/mod.rs
@@ -330,9 +330,26 @@ macro_rules! kotlin_type_renderer {
                 ""
             }
 
+              fn is_name_serializable(&self, name: &str) -> bool {
+                        if self
+							.config
+							.skip_serializer_for()
+							.contains(&name.to_string())
+						{
+							return false;
+						}
+                        true
+				}
             // Helper to check if a record can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_serializable(&self, rec: &Record) -> bool {
+            if self
+                                .config
+                                .skip_serializer_for()
+                                .contains(&rec.name().to_string())
+                            {
+                                return false;
+                            }
                 for f in rec.fields() {
                     for inner_ty in f.iter_types() {
                         match inner_ty {
@@ -346,9 +363,29 @@ macro_rules! kotlin_type_renderer {
                 }
                 true
             }
+             // Helper to check if a enum variant can be serialized
+                                    // We only allow records that store primitive types or other records and enums
+            			fn is_enum_serializable(&self, rec: &Enum) -> bool {
+            				if self
+            					.config
+            					.skip_serializer_for()
+            					.contains(&rec.name().to_string())
+            				{
+            					return false;
+            				}
+            				true
+            			}
+
             // Helper to check if a enum variant can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_variant_serializable(&self, rec: &Variant) -> bool {
+               if self
+                                   .config
+                                   .skip_serializer_for()
+                                   .contains(&rec.name().to_string())
+                               {
+                                   return false;
+                               }
                 for f in rec.fields() {
                     for inner_ty in f.iter_types() {
                         match inner_ty {

--- a/bindgen-bootstrap/src/gen_kotlin_multiplatform/mod.rs
+++ b/bindgen-bootstrap/src/gen_kotlin_multiplatform/mod.rs
@@ -330,26 +330,26 @@ macro_rules! kotlin_type_renderer {
                 ""
             }
 
-              fn is_name_serializable(&self, name: &str) -> bool {
-                        if self
-							.config
-							.skip_serializer_for()
-							.contains(&name.to_string())
-						{
-							return false;
-						}
-                        true
-				}
+            fn is_name_serializable(&self, name: &str) -> bool {
+                if self
+                    .config
+                    .skip_serializer_for()
+                    .contains(&name.to_string())
+                {
+                    return false;
+                }
+                true
+            }
             // Helper to check if a record can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_serializable(&self, rec: &Record) -> bool {
-            if self
-                                .config
-                                .skip_serializer_for()
-                                .contains(&rec.name().to_string())
-                            {
-                                return false;
-                            }
+                if self
+                    .config
+                    .skip_serializer_for()
+                    .contains(&rec.name().to_string())
+                {
+                    return false;
+                }
                 for f in rec.fields() {
                     for inner_ty in f.iter_types() {
                         match inner_ty {
@@ -363,29 +363,29 @@ macro_rules! kotlin_type_renderer {
                 }
                 true
             }
-             // Helper to check if a enum variant can be serialized
-                                    // We only allow records that store primitive types or other records and enums
-            			fn is_enum_serializable(&self, rec: &Enum) -> bool {
-            				if self
-            					.config
-            					.skip_serializer_for()
-            					.contains(&rec.name().to_string())
-            				{
-            					return false;
-            				}
-            				true
-            			}
+            // Helper to check if a enum variant can be serialized
+            // We only allow records that store primitive types or other records and enums
+            fn is_enum_serializable(&self, rec: &Enum) -> bool {
+                if self
+                    .config
+                    .skip_serializer_for()
+                    .contains(&rec.name().to_string())
+                {
+                    return false;
+                }
+                true
+            }
 
             // Helper to check if a enum variant can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_variant_serializable(&self, rec: &Variant) -> bool {
-               if self
-                                   .config
-                                   .skip_serializer_for()
-                                   .contains(&rec.name().to_string())
-                               {
-                                   return false;
-                               }
+                if self
+                    .config
+                    .skip_serializer_for()
+                    .contains(&rec.name().to_string())
+                {
+                    return false;
+                }
                 for f in rec.fields() {
                     for inner_ty in f.iter_types() {
                         match inner_ty {

--- a/bindgen-bootstrap/src/gen_kotlin_multiplatform/mod.rs
+++ b/bindgen-bootstrap/src/gen_kotlin_multiplatform/mod.rs
@@ -339,25 +339,18 @@ macro_rules! kotlin_type_renderer {
             }
 
             fn is_name_serializable(&self, name: &str) -> bool {
-                if self
+                !self
                     .config
                     .skip_serializer_for()
                     .contains(&name.to_string())
-                {
-                    return false;
-                }
-                true
             }
             // Helper to check if a record can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_serializable(&self, rec: &Record) -> bool {
-                if self
-                    .config
-                    .skip_serializer_for()
-                    .contains(&rec.name().to_string())
-                {
+                if !self.is_name_serializable(rec.name()) {
                     return false;
                 }
+
                 for f in rec.fields() {
                     for inner_ty in f.iter_types() {
                         match inner_ty {
@@ -374,26 +367,16 @@ macro_rules! kotlin_type_renderer {
             // Helper to check if a enum variant can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_enum_serializable(&self, rec: &Enum) -> bool {
-                if self
-                    .config
-                    .skip_serializer_for()
-                    .contains(&rec.name().to_string())
-                {
-                    return false;
-                }
-                true
+                self.is_name_serializable(rec.name())
             }
 
             // Helper to check if a enum variant can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_variant_serializable(&self, rec: &Variant) -> bool {
-                if self
-                    .config
-                    .skip_serializer_for()
-                    .contains(&rec.name().to_string())
-                {
+                if !self.is_name_serializable(rec.name()) {
                     return false;
                 }
+
                 for f in rec.fields() {
                     for inner_ty in f.iter_types() {
                         match inner_ty {

--- a/bindgen-bootstrap/src/gen_kotlin_multiplatform/mod.rs
+++ b/bindgen-bootstrap/src/gen_kotlin_multiplatform/mod.rs
@@ -108,6 +108,7 @@ pub struct Config {
     kotlin_target_version: Option<String>,
     #[serde(default)]
     disable_java_cleaner: bool,
+    skip_serializer_for: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -155,6 +156,13 @@ impl Config {
 
     pub(crate) fn use_enum_entries(&self) -> bool {
         self.get_kotlin_version() >= KotlinVersion::new(1, 9, 0)
+    }
+
+    pub fn skip_serializer_for(&self) -> Vec<String> {
+        self.skip_serializer_for
+            .as_ref()
+            .cloned()
+            .unwrap_or_default()
     }
 
     /// Returns a `Version` with the contents of `kotlin_target_version`.

--- a/bindgen/src/gen_kotlin_multiplatform/mod.rs
+++ b/bindgen/src/gen_kotlin_multiplatform/mod.rs
@@ -384,15 +384,15 @@ macro_rules! kotlin_type_renderer {
             }
 
             fn is_name_serializable(&self, name: &str) -> bool {
-                                    if self
-            							.config
-            							.skip_serializer_for()
-            							.contains(&name.to_string())
-            						{
-            							return false;
-            						}
-                                    true
-            				}
+                if self
+                    .config
+                    .skip_serializer_for()
+                    .contains(&name.to_string())
+                {
+                    return false;
+                }
+                true
+            }
 
             // Helper to check if a record can be serialized
             // We only allow records that store primitive types or other records and enums
@@ -418,17 +418,17 @@ macro_rules! kotlin_type_renderer {
                 true
             }
             // Helper to check if a enum variant can be serialized
-                        // We only allow records that store primitive types or other records and enums
-			fn is_enum_serializable(&self, rec: &Enum) -> bool {
-				if self
-					.config
-					.skip_serializer_for()
-					.contains(&rec.name().to_string())
-				{
-					return false;
-				}
-				true
-			}
+            // We only allow records that store primitive types or other records and enums
+            fn is_enum_serializable(&self, rec: &Enum) -> bool {
+                if self
+                    .config
+                    .skip_serializer_for()
+                    .contains(&rec.name().to_string())
+                {
+                    return false;
+                }
+                true
+            }
 
             // Helper to check if a enum variant can be serialized
             // We only allow records that store primitive types or other records and enums

--- a/bindgen/src/gen_kotlin_multiplatform/mod.rs
+++ b/bindgen/src/gen_kotlin_multiplatform/mod.rs
@@ -98,6 +98,7 @@ pub struct Config {
     pub(super) cdylib_name: Option<String>,
     generate_immutable_records: Option<bool>,
     generate_serializable_records: Option<bool>,
+    skip_serializer_for: Option<Vec<String>>,
     import_pointer_from: Option<Vec<String>>,
     #[serde(default)]
     custom_types: HashMap<String, CustomTypeConfig>,
@@ -140,6 +141,12 @@ impl Config {
     /// Whether to use kotlinx Serializable annotation on the data class
     pub fn generate_serializable_records(&self) -> bool {
         self.generate_serializable_records.unwrap_or(false)
+    }
+    pub fn skip_serializer_for(&self) -> Vec<String> {
+        self.skip_serializer_for
+            .as_ref()
+            .cloned()
+            .unwrap_or_default()
     }
     /// Whether to use kotlinx Serializable annotation on the data class
     pub fn has_import_helpers(&self) -> bool {
@@ -376,9 +383,27 @@ macro_rules! kotlin_type_renderer {
                 ""
             }
 
+            fn is_name_serializable(&self, name: &str) -> bool {
+                                    if self
+            							.config
+            							.skip_serializer_for()
+            							.contains(&name.to_string())
+            						{
+            							return false;
+            						}
+                                    true
+            				}
+
             // Helper to check if a record can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_serializable(&self, rec: &Record) -> bool {
+                if self
+                    .config
+                    .skip_serializer_for()
+                    .contains(&rec.name().to_string())
+                {
+                    return false;
+                }
                 for f in rec.fields() {
                     for inner_ty in f.iter_types() {
                         match inner_ty {
@@ -393,8 +418,28 @@ macro_rules! kotlin_type_renderer {
                 true
             }
             // Helper to check if a enum variant can be serialized
+                        // We only allow records that store primitive types or other records and enums
+			fn is_enum_serializable(&self, rec: &Enum) -> bool {
+				if self
+					.config
+					.skip_serializer_for()
+					.contains(&rec.name().to_string())
+				{
+					return false;
+				}
+				true
+			}
+
+            // Helper to check if a enum variant can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_variant_serializable(&self, rec: &Variant) -> bool {
+                if self
+                    .config
+                    .skip_serializer_for()
+                    .contains(&rec.name().to_string())
+                {
+                    return false;
+                }
                 for f in rec.fields() {
                     for inner_ty in f.iter_types() {
                         match inner_ty {

--- a/bindgen/src/gen_kotlin_multiplatform/mod.rs
+++ b/bindgen/src/gen_kotlin_multiplatform/mod.rs
@@ -384,24 +384,16 @@ macro_rules! kotlin_type_renderer {
             }
 
             fn is_name_serializable(&self, name: &str) -> bool {
-                if self
+                !self
                     .config
                     .skip_serializer_for()
                     .contains(&name.to_string())
-                {
-                    return false;
-                }
-                true
             }
 
             // Helper to check if a record can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_serializable(&self, rec: &Record) -> bool {
-                if self
-                    .config
-                    .skip_serializer_for()
-                    .contains(&rec.name().to_string())
-                {
+                if !self.is_name_serializable(rec.name()) {
                     return false;
                 }
                 for f in rec.fields() {
@@ -420,24 +412,13 @@ macro_rules! kotlin_type_renderer {
             // Helper to check if a enum variant can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_enum_serializable(&self, rec: &Enum) -> bool {
-                if self
-                    .config
-                    .skip_serializer_for()
-                    .contains(&rec.name().to_string())
-                {
-                    return false;
-                }
-                true
+                self.is_name_serializable(rec.name())
             }
 
             // Helper to check if a enum variant can be serialized
             // We only allow records that store primitive types or other records and enums
             fn is_variant_serializable(&self, rec: &Variant) -> bool {
-                if self
-                    .config
-                    .skip_serializer_for()
-                    .contains(&rec.name().to_string())
-                {
+                if !self.is_name_serializable(rec.name()) {
                     return false;
                 }
                 for f in rec.fields() {

--- a/bindgen/src/templates/common/EnumTemplate.kt
+++ b/bindgen/src/templates/common/EnumTemplate.kt
@@ -11,7 +11,7 @@
 {%- call kt::docstring(e, 0) %}
 {% match e.variant_discr_type() %}
 {% when None %}
-{%- if config.generate_serializable_records() %}
+{%- if config.generate_serializable_records() && self.is_enum_serializable(e) %}
 @kotlinx.serialization.Serializable
 {% endif%}
 enum class {{ type_name }} {
@@ -22,7 +22,7 @@ enum class {{ type_name }} {
     companion object
 }
 {% when Some with (variant_discr_type) %}
-{%- if config.generate_serializable_records() %}
+{%- if config.generate_serializable_records() && self.is_enum_serializable(e) %}
 @kotlinx.serialization.Serializable
 {% endif%}
 enum class {{ type_name }}(val value: {{ variant_discr_type|type_name(ci) }}) {
@@ -35,7 +35,7 @@ enum class {{ type_name }}(val value: {{ variant_discr_type|type_name(ci) }}) {
 {% endmatch %}
 {% else %}
 
-{%- if !contains_object_references && config.generate_serializable_records() %}
+    {%- if !contains_object_references && config.generate_serializable_records() && self.is_enum_serializable(e) %}
 
 {%  for variant in e.variants() %}
 {% if variant.has_fields() && variant.fields().len() == 1 && variant.fields()[0].name()|var_name|unquote == "" %}
@@ -76,7 +76,7 @@ object {{ type_name }}PolySerializer : kotlinx.serialization.json.JsonContentPol
 
         {%- for variant in e.variants() -%}
         {% if variant.has_fields() %}
-        
+
         {%- for field in variant.fields() -%}
 
             {%- let fieldNameInternal = field.name()|var_name|unquote %}

--- a/bindgen/src/templates/common/RecordTemplate.kt
+++ b/bindgen/src/templates/common/RecordTemplate.kt
@@ -3,15 +3,15 @@
 
 {%- if rec.has_fields() %}
 {%- call kt::docstring(rec, 0) %}
-{%- if config.generate_serializable_records() && self.is_serializable(rec) %}
+{%- if config.generate_serializable_records() && self.is_name_serializable(type_name) %}
 @kotlinx.serialization.Serializable
 {% endif%}
 data class {{ type_name }} (
     {%- for field in rec.fields() %}
     {%- call kt::docstring(field, 4) %}
-    {%- if config.generate_serializable_records() && self.is_serializable(rec) %}
+    {%- if config.generate_serializable_records() && self.is_name_serializable(type_name)  %}
     @kotlinx.serialization.json.JsonNames("{% call kt::field_name_unquoted_unescaped(field, loop.index) %}")
-    {%- if !field.name().is_empty() %}
+    {%- if !field.name().is_empty() && self.is_name_serializable(type_name)  %}
     @kotlinx.serialization.SerialName("{{ field.name() }}")
     {%- endif -%}
     {%- endif %}


### PR DESCRIPTION
Allow skipping serializer configuration of structs. In case the structs are "too" complicated to serialize with the KMP Polymorphism, but we need them in KMP, we can still do it.