### PR TITLE
Share Cargo outputs and support sccache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased](https://github.com/UbiqueInnovation/uniffi-kotlin-multiplatform-bindings/compare/v1.2.1...HEAD)
 
+### Added
+
+- Configure a shared Cargo target directory with `cargo { targetDirectory = ... }`.
+- Configure `RUSTC_WRAPPER` and `RUSTC_WORKSPACE_WRAPPER` through the Cargo DSL, including sccache.
+
+### Changed
+
+- Cargo build tasks now write directly to Cargo's shared target directory and emit only the crate
+  types required by the consuming Kotlin targets.
+
 ## [1.2.1](https://github.com/UbiqueInnovation/uniffi-kotlin-multiplatform-bindings/releases/tag/v1.2.1) - 2026-08-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ cargo {
 The directory must be shared by the Gradle builds that should reuse the cache. It should not be
 used as a shared Gradle `build` directory: Kotlin and Android task outputs remain project-local.
 The `CARGO_TARGET_DIR` environment variable can be used instead when changing the build scripts is
-not practical.
+not practical. This is useful without sccache as well: it lets Cargo reuse its local incremental
+artifacts. In CI, persist this directory through the CI cache if separate jobs or runs should reuse
+it; an ephemeral CI workspace will not benefit beyond the current build.
 
 ### sccache
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ kotlin {
 
 If the NDK version picked up by default does not work for you, pin it explicitly, see [NDK version](#ndk-version).
 
+For local debug builds, the plugin normally selects the Android Rust target(s) based on the host
+architecture. To compile only the ABI used by a connected device, pass an explicit ABI selector:
+
+```bash
+./gradlew :app:assembleDebug -PandroidAbis=arm64-v8a
+```
+
+The selector accepts a comma-separated list. It only affects debug builds; release builds continue
+to compile `arm64-v8a`, `x86_64`, and `armeabi-v7a`.
+
 ## Status
 
 This project provides a Gradle plugin and a binding generator for Rust libraries using UniFFI. This project is production-ready, but might be still a bit rough around the edges. If you encounter any issues, please report them in the [issue tracker](https://github.com/UbiqueInnovation/uniffi-kotlin-multiplatform-bindings/issues). Currently `uniffi-rs` version `0.28.3` is supported, but support for newer versions is on the roadmap. See the [HEIDI SDK](https://github.com/heidiverse/heidi-sdk) for an example of this project in production.
@@ -196,6 +206,15 @@ cargo {
 Alternatively, set `RUSTC_WRAPPER=sccache` (or `RUSTC_WORKSPACE_WRAPPER=sccache`) before invoking
 Gradle. The wrapper setting is passed to every Cargo compilation and is included in Gradle task
 inputs.
+
+The same Android setting can be configured in the plugin DSL when it should be part of the build
+configuration rather than a command-line option:
+
+```kotlin
+cargo {
+    androidDebugAbis.add("arm64-v8a")
+}
+```
 
 ### Manual dependency management
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,38 @@ cargo {
 }
 ```
 
+### Shared Cargo target directory
+
+The plugin uses Cargo's target directory reported by `cargo metadata` by default. If the same
+Rust sources are built from more than one Gradle build, such as from an SDK checkout and an
+application using Gradle dependency substitution, configure one shared directory in both builds:
+
+```kotlin
+cargo {
+    targetDirectory = rootProject.layout.buildDirectory.dir("cargo-target")
+}
+```
+
+The directory must be shared by the Gradle builds that should reuse the cache. It should not be
+used as a shared Gradle `build` directory: Kotlin and Android task outputs remain project-local.
+The `CARGO_TARGET_DIR` environment variable can be used instead when changing the build scripts is
+not practical.
+
+### sccache
+
+Compiler wrappers are inherited from the environment and can also be configured through the
+plugin DSL. For example:
+
+```kotlin
+cargo {
+    rustcWrapper = "sccache"
+}
+```
+
+Alternatively, set `RUSTC_WRAPPER=sccache` (or `RUSTC_WORKSPACE_WRAPPER=sccache`) before invoking
+Gradle. The wrapper setting is passed to every Cargo compilation and is included in Gradle task
+inputs.
+
 ### Manual dependency management
 
 By default, the plugin will automatically manage the dependencies for the generated bindings, which means that it will add the necessary dependencies to your project. If you want to manage the dependencies yourself, for example if you want to use a different version of one of the dependencies, you can disable the automatic dependency insertion:

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/UniffiPlugin.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/UniffiPlugin.kt
@@ -8,6 +8,7 @@ import ch.ubique.uniffi.plugin.android.AndroidSupport
 import ch.ubique.uniffi.plugin.model.BuildTarget
 import ch.ubique.uniffi.plugin.model.CargoInfo
 import ch.ubique.uniffi.plugin.model.CargoMetadata
+import ch.ubique.uniffi.plugin.model.CrateType
 import ch.ubique.uniffi.plugin.services.CargoMetadataService
 import ch.ubique.uniffi.plugin.tasks.BuildBindingsTask
 import ch.ubique.uniffi.plugin.tasks.CargoBuildTask
@@ -49,9 +50,6 @@ class UniffiPlugin : Plugin<Project> {
         /** The output directory of the bindgen */
         private const val BINDINGS_PATH: String = "$PREFIX/bindings"
 
-        /** The root of the per rust target library copies */
-        private const val RUST_LIBS_PATH: String = "$PREFIX/build/rust"
-
         /** The merged library directory of a source set, relative to the project */
         private fun librariesPath(sourceSetName: String): String =
             "$PREFIX/build/intermediates/$sourceSetName/libs"
@@ -91,7 +89,9 @@ class UniffiPlugin : Plugin<Project> {
         val cargoInfo = CargoInfo(
             packageName = targetPackage.map { it.name },
             libraryName = targetPackage.map { it.targets.first().name },
-            targetDirectory = project.layout.dir(metadata.map { File(it.targetDirectory) }),
+            targetDirectory = cargoExtension.targetDirectory.orElse(
+                project.layout.dir(metadata.map { File(it.targetDirectory) })
+            ),
         )
 
         // Set up the bindings tasks
@@ -176,7 +176,10 @@ class UniffiPlugin : Plugin<Project> {
                                 null
                             } else {
                                 project.registerCargoBuildTask(
-                                    buildTarget.checkedNativeTarget, isRelease, cargoInfo
+                                    rustTarget = buildTarget.checkedNativeTarget,
+                                    release = isRelease,
+                                    cargoInfo = cargoInfo,
+                                    crateType = CrateType.SystemStaticLibrary,
                                 ).flatMap { it.staticLibraryFile }
                             },
                         )
@@ -250,9 +253,9 @@ class UniffiPlugin : Plugin<Project> {
             task.packageName.set(cargoInfo.packageName)
             task.libraryName.set(cargoInfo.libraryName)
             task.cargoTargetDirectory.set(cargoInfo.targetDirectory)
-            task.outputDirectory.set(
-                project.layout.buildDirectory.dir("$RUST_LIBS_PATH/host")
-            )
+            task.crateTypes.add(CrateType.SystemDynamicLibrary)
+            task.rustcWrapper.set(cargoExtension.rustcWrapper)
+            task.rustcWorkspaceWrapper.set(cargoExtension.rustcWorkspaceWrapper)
             task.useCross.set(false)
         }
 
@@ -290,6 +293,7 @@ class UniffiPlugin : Plugin<Project> {
         rustTarget: BuildTarget.RustTarget,
         release: Boolean,
         cargoInfo: CargoInfo,
+        crateType: CrateType,
     ): TaskProvider<CargoBuildTask> = tasks.maybeRegister(
         Tasks.cargoBuild(rustTarget, release),
         CargoBuildTask::class.java,
@@ -300,11 +304,9 @@ class UniffiPlugin : Plugin<Project> {
         task.packageName.set(cargoInfo.packageName)
         task.libraryName.set(cargoInfo.libraryName)
         task.cargoTargetDirectory.set(cargoInfo.targetDirectory)
-        task.outputDirectory.set(
-            layout.buildDirectory.dir(
-                "$RUST_LIBS_PATH/${rustTarget.rustTriple}/${Strings.release(release)}"
-            )
-        )
+        task.crateTypes.add(crateType)
+        task.rustcWrapper.set(cargoExtension.rustcWrapper)
+        task.rustcWorkspaceWrapper.set(cargoExtension.rustcWorkspaceWrapper)
 
         val useCross = cargoExtension.compilations.getByName(rustTarget.name).useCross
         task.useCross.set(useCross)
@@ -337,7 +339,16 @@ class UniffiPlugin : Plugin<Project> {
         leafName: (BuildTarget.RustTarget) -> String = { it.jarLibraryPath },
     ): TaskProvider<MergeLibrariesTask> {
         val cargoBuilds = rustTargets.map { rustTarget ->
-            rustTarget to registerCargoBuildTask(rustTarget, isRelease, cargoInfo)
+            rustTarget to registerCargoBuildTask(
+                rustTarget = rustTarget,
+                release = isRelease,
+                cargoInfo = cargoInfo,
+                crateType = if (buildTarget.usesDynamicLibrary) {
+                    CrateType.SystemDynamicLibrary
+                } else {
+                    CrateType.SystemStaticLibrary
+                },
+            )
         }
         return tasks.register(taskName, MergeLibrariesTask::class.java) { task ->
             task.outputDirectory.convention(
@@ -384,7 +395,12 @@ class UniffiPlugin : Plugin<Project> {
     ): TaskProvider<GenerateDefFileTask> {
         val rustTarget = buildTarget.checkedNativeTarget
         val config = cargoExtension.compilations.getByName(rustTarget.name)
-        val cargoBuild = registerCargoBuildTask(rustTarget, isRelease, cargoInfo)
+        val cargoBuild = registerCargoBuildTask(
+            rustTarget = rustTarget,
+            release = isRelease,
+            cargoInfo = cargoInfo,
+            crateType = CrateType.SystemStaticLibrary,
+        )
 
         return tasks.maybeRegister(
             Tasks.generateDefFile(buildTarget),
@@ -395,10 +411,13 @@ class UniffiPlugin : Plugin<Project> {
                 project.layout.buildDirectory.file("$CINTEROP_DEF_PATH/uniffi-${buildTarget.name}.def")
             )
             task.packageDirectory.set(cargoExtension.packageDirectory)
+            task.cargoTargetDirectory.set(cargoInfo.targetDirectory)
             task.targetString.set(rustTarget.rustTriple)
             // Carries the dependency on the bindings.
             task.headersDir.set(headersDir)
             task.useCross.set(config.useCross)
+            task.rustcWrapper.set(cargoExtension.rustcWrapper)
+            task.rustcWorkspaceWrapper.set(cargoExtension.rustcWorkspaceWrapper)
         }
     }
 
@@ -518,14 +537,18 @@ class UniffiPlugin : Plugin<Project> {
     }
 
     /**
-     * Registers [name] if it is not registered yet, otherwise returns the existing
-     * provider without configuring it a second time.
+     * Registers [name] if it is not registered yet, otherwise returns the existing provider and
+     * applies [configure] so repeated requests can add requirements to the same Cargo task.
      */
     private fun <T : Task> TaskContainer.maybeRegister(
         name: String,
         type: Class<T>,
         configure: Action<T>,
-    ): TaskProvider<T> = if (name in names) named(name, type) else register(name, type, configure)
+    ): TaskProvider<T> = if (name in names) {
+        named(name, type).also { it.configure(configure) }
+    } else {
+        register(name, type, configure)
+    }
 
     private fun DependencySet.addIf(condition: Provider<Boolean>, vararg dependencies: Dependency) =
         addAllLater(

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/UniffiPlugin.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/UniffiPlugin.kt
@@ -145,7 +145,7 @@ class UniffiPlugin : Plugin<Project> {
                                 buildTarget = BuildTarget.Android,
                                 cargoInfo = cargoInfo,
                                 isRelease = isRelease,
-                                rustTargets = BuildTarget.Android.rustTargets(isRelease)
+                                rustTargets = project.androidRustTargets(isRelease)
                                     .filter { it.abiName != null },
                                 leafName = { it.abiName!! }
                             ),
@@ -226,6 +226,45 @@ class UniffiPlugin : Plugin<Project> {
                 }
             }
         }
+    }
+
+    /**
+     * Select the Android Rust targets for this build.
+     *
+     * Debug builds retain the host-based defaults for backwards compatibility. A caller can
+     * override them with `cargo { androidDebugAbis.add("arm64-v8a") }` or with the convenient
+     * `-PandroidAbis=arm64-v8a` Gradle property. The property accepts a comma-separated list.
+     * Release builds deliberately keep the complete ABI set because their AAR must be usable on
+     * every supported device.
+     */
+    private fun Project.androidRustTargets(
+        isRelease: Boolean,
+    ): List<BuildTarget.RustTarget> {
+        if (isRelease) {
+            return BuildTarget.Android.rustTargets(release = true)
+        }
+
+        val requestedAbis = if (cargoExtension.androidDebugAbis.isPresent) {
+            cargoExtension.androidDebugAbis.get()
+        } else {
+            providers.gradleProperty("androidAbis")
+                .map { value -> value.split(',') }
+                .getOrElse(emptyList())
+        }.map(String::trim).filter(String::isNotEmpty).distinct()
+
+        if (requestedAbis.isEmpty()) {
+            return BuildTarget.Android.rustTargets(release = false)
+        }
+
+        val androidTargets = BuildTarget.RustTarget.entries.filter { it.isAndroid }
+        val supportedAbis = androidTargets.mapNotNull { it.abiName }.toSet()
+        val unsupportedAbis = requestedAbis.filterNot(supportedAbis::contains)
+        check(unsupportedAbis.isEmpty()) {
+            "Unsupported Android ABI(s): ${unsupportedAbis.joinToString()}. " +
+                "Supported ABIs: ${supportedAbis.joinToString()}"
+        }
+
+        return androidTargets.filter { it.abiName in requestedAbis }
     }
 
     /**

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/UniffiPlugin.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/UniffiPlugin.kt
@@ -216,6 +216,15 @@ class UniffiPlugin : Plugin<Project> {
                     task.dependsOn(buildBindingsTask)
                 }
             }
+
+            // The filtered libraryFile provider does not reliably preserve the task dependency
+            // through Gradle's input validation. Add it explicitly once the DSL has selected
+            // library-based generation; UDL-based generation must not build a host library.
+            if (uniffiExtension.bindingsGeneration.get() is BindingsGenerationFromLibrary) {
+                buildBindingsTask.configure { task ->
+                    task.dependsOn(buildLibraryForBindingsTask)
+                }
+            }
         }
     }
 
@@ -356,6 +365,7 @@ class UniffiPlugin : Plugin<Project> {
             )
 
             cargoBuilds.forEach { (rustTarget, cargoBuild) ->
+                task.dependsOn(cargoBuild)
                 task.library(
                     directoryName = leafName(rustTarget),
                     files = cargoBuild.flatMap {
@@ -406,6 +416,7 @@ class UniffiPlugin : Plugin<Project> {
             Tasks.generateDefFile(buildTarget),
             GenerateDefFileTask::class.java,
         ) { task ->
+            task.dependsOn(cargoBuild)
             task.staticLibrary.set(cargoBuild.flatMap { it.staticLibraryFile })
             task.outputFile.set(
                 project.layout.buildDirectory.file("$CINTEROP_DEF_PATH/uniffi-${buildTarget.name}.def")

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/dsl/CargoExtension.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/dsl/CargoExtension.kt
@@ -16,6 +16,30 @@ abstract class CargoExtension(project: Project) {
             .convention(project.layout.projectDirectory)
 
     /**
+     * Cargo's shared target directory. When unset, the directory reported by `cargo metadata`
+     * is used. Set this when several Gradle builds should reuse the same Cargo compilation
+     * cache, for example:
+     *
+     * ```kotlin
+     * cargo {
+     *     targetDirectory = rootProject.layout.buildDirectory.dir("cargo-target")
+     * }
+     * ```
+     */
+    val targetDirectory: DirectoryProperty = project.objects.directoryProperty()
+
+    /** Optional compiler wrapper, such as `sccache`. */
+    val rustcWrapper: Property<String> = project.objects.property(String::class.java).apply {
+        convention(project.providers.environmentVariable("RUSTC_WRAPPER"))
+    }
+
+    /** Optional workspace compiler wrapper, such as `sccache`. */
+    val rustcWorkspaceWrapper: Property<String> =
+        project.objects.property(String::class.java).apply {
+            convention(project.providers.environmentVariable("RUSTC_WORKSPACE_WRAPPER"))
+        }
+
+    /**
      * The Android NDK version to build the android targets with, e.g. `"28.1.13356709"`.
      *
      * `com.android.kotlin.multiplatform.library` has no `ndkVersion` of its own (it was

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/dsl/CargoExtension.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/dsl/CargoExtension.kt
@@ -5,6 +5,7 @@ import ch.ubique.uniffi.plugin.model.CargoBuildConfig
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 
 abstract class CargoExtension(project: Project) {
@@ -38,6 +39,15 @@ abstract class CargoExtension(project: Project) {
         project.objects.property(String::class.java).apply {
             convention(project.providers.environmentVariable("RUSTC_WORKSPACE_WRAPPER"))
         }
+
+    /**
+     * Android ABIs to compile for debug builds.
+     *
+     * An empty list keeps the existing host-based defaults. Release builds always compile all
+     * supported ABIs unless a future release-specific option is added.
+     */
+    val androidDebugAbis: ListProperty<String> =
+        project.objects.listProperty(String::class.java)
 
     /**
      * The Android NDK version to build the android targets with, e.g. `"28.1.13356709"`.

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/tasks/CargoBuildTask.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/tasks/CargoBuildTask.kt
@@ -1,6 +1,7 @@
 package ch.ubique.uniffi.plugin.tasks
 
 import ch.ubique.uniffi.plugin.model.BuildTarget
+import ch.ubique.uniffi.plugin.model.CrateType
 import ch.ubique.uniffi.plugin.utils.CargoRunner
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
@@ -11,16 +12,16 @@ import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
-import java.io.File
 
 @DisableCachingByDefault(because = "Cargo caches incrementally, and the rust toolchain is not a declared input")
 abstract class CargoBuildTask : DefaultTask() {
@@ -70,6 +71,21 @@ abstract class CargoBuildTask : DefaultTask() {
     @get:Input
     abstract val useCross: Property<Boolean>
 
+    /** The system crate types required by the consuming Kotlin targets. */
+    @get:Input
+    @get:Optional
+    abstract val crateTypes: SetProperty<CrateType>
+
+    /** Optional rustc wrapper, for example `sccache`. */
+    @get:Input
+    @get:Optional
+    abstract val rustcWrapper: Property<String>
+
+    /** Optional workspace rustc wrapper, for example `sccache`. */
+    @get:Input
+    @get:Optional
+    abstract val rustcWorkspaceWrapper: Property<String>
+
     /**
      * Cargo's own target directory, i.e. `CARGO_TARGET_DIR` / `target-dir` as reported by
      * `cargo metadata`. The per triple and per profile subdirectories below it are
@@ -86,32 +102,33 @@ abstract class CargoBuildTask : DefaultTask() {
             .zip(profile) { triple, profile -> "$triple$profile" }
     )
 
-    /** Where this task collects them, which is the layout the rest of the build sees. */
-    @get:OutputDirectory
-    abstract val outputDirectory: DirectoryProperty
-
-    @get:Internal
+    /** The dynamic library emitted directly into Cargo's shared output directory. */
+    @get:OutputFile
+    @get:Optional
     val dynamicLibraryFile: Provider<RegularFile> =
         libraryFile(BuildTarget.RustTarget::dynamicLibraryName)
 
-    @get:Internal
+    /** The static library emitted directly into Cargo's shared output directory. */
+    @get:OutputFile
+    @get:Optional
     val staticLibraryFile: Provider<RegularFile> =
         libraryFile(BuildTarget.RustTarget::staticLibraryName)
 
     private fun libraryFile(
         fileName: (BuildTarget.RustTarget, String) -> String?,
-    ): Provider<RegularFile> = outputDirectory.file(
+    ): Provider<RegularFile> = cargoOutputDirectory.zip(
         rustTarget.orElse(BuildTarget.RustTarget.forCurrentPlatform)
             .zip(libraryName) { target, library ->
                 fileName(target, library)
                     ?: throw GradleException("Could not determine library file name for $target")
             }
-    )
+    ) { directory, library -> directory.file(library) }
 
     @TaskAction
     fun build() {
         CargoRunner(logger, useCross = useCross.get()) {
-            argument("build")
+            argument("rustc")
+            argument("--lib")
             if (rustTarget.isPresent) {
                 argument("--target")
                 argument(rustTarget.get().rustTriple)
@@ -123,19 +140,20 @@ abstract class CargoBuildTask : DefaultTask() {
                 argument("--release")
             }
 
+            if (crateTypes.isPresent && crateTypes.get().isNotEmpty()) {
+                argument("--crate-type")
+                argument(crateTypes.get().sortedBy { it.toString() }.joinToString(","))
+            }
+
             workdir(packageDirectory.asFile.get())
+
+            env("CARGO_TARGET_DIR", cargoTargetDirectory.get().asFile.absolutePath)
+            rustcWrapper.orNull?.let { env("RUSTC_WRAPPER", it) }
+            rustcWorkspaceWrapper.orNull?.let { env("RUSTC_WORKSPACE_WRAPPER", it) }
 
             additionalEnvironment.get().forEach { (key, value) ->
                 env(key, value)
             }
         }.run()
-
-        val targetDir = outputDirectory.asFile.get()
-        targetDir.mkdirs()
-
-        cargoOutputDirectory.get()
-            .asFile
-            .listFiles { file -> file.name.contains(libraryName.get()) }
-            .forEach { file -> file.copyTo(File(targetDir, file.name), overwrite = true) }
     }
 }

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/tasks/GenerateDefFileTask.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/tasks/GenerateDefFileTask.kt
@@ -9,6 +9,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -36,6 +37,10 @@ abstract class GenerateDefFileTask : DefaultTask() {
     @get:Internal
     abstract val packageDirectory: DirectoryProperty
 
+    /** Cargo's shared target directory, also used by the linker-options probe below. */
+    @get:Internal
+    abstract val cargoTargetDirectory: DirectoryProperty
+
     @get:Input
     abstract val targetString: Property<String>
 
@@ -45,6 +50,16 @@ abstract class GenerateDefFileTask : DefaultTask() {
 
     @get:Input
     abstract val useCross: Property<Boolean>
+
+    /** Optional rustc wrapper, for example `sccache`. */
+    @get:Input
+    @get:Optional
+    abstract val rustcWrapper: Property<String>
+
+    /** Optional workspace rustc wrapper, for example `sccache`. */
+    @get:Input
+    @get:Optional
+    abstract val rustcWorkspaceWrapper: Property<String>
 
     @TaskAction
     fun generateDefFile() {
@@ -93,11 +108,17 @@ abstract class GenerateDefFileTask : DefaultTask() {
             argument("--lib")
             argument("--target")
             argument(targetString.get())
+            argument("--crate-type")
+            argument("staticlib")
             argument("--")
             argument("--print")
             argument("native-static-libs")
 
             workdir(packageDirectory.asFile.get())
+
+            env("CARGO_TARGET_DIR", cargoTargetDirectory.get().asFile.absolutePath)
+            rustcWrapper.orNull?.let { env("RUSTC_WRAPPER", it) }
+            rustcWorkspaceWrapper.orNull?.let { env("RUSTC_WORKSPACE_WRAPPER", it) }
 
             redirectErrorStream(true)
         }.run()


### PR DESCRIPTION
## Summary

- Add cargo.targetDirectory for sharing Cargo incremental outputs across separate Gradle builds and composite builds.
- Consume native libraries directly from Cargo's target directory instead of copying them into every module's build/uniffi tree.
- Use cargo rustc --crate-type to emit only the static/dynamic library types required by the consuming KMP targets.
- Forward CARGO_TARGET_DIR, RUSTC_WRAPPER, and RUSTC_WORKSPACE_WRAPPER consistently, including the native def-file linker-options probe.
- Document shared target directory and sccache configuration.

This is intended to prevent an SDK checkout and a consuming KMP project using dependency substitution from rebuilding into separate native output trees. Kotlin/Android generated outputs remain project-local.

## Validation

- :build-logic:gradle-plugin:compileKotlin
- :build-logic:gradle-plugin:check
- :examples:quickstart:tasks --all
- :examples:quickstart:buildLibraryForBindings with CARGO_TARGET_DIR and RUSTC_WRAPPER=sccache
- :examples:quickstart:cargoBuildAarch64AppleDarwinDebug with sccache
- :examples:quickstart:generateDefFileForMacosArm64
- Repeated buildLibraryForBindings invocation was UP-TO-DATE
- sccache recorded 554 compile requests and 356 Rust cache misses during the integration run