### PR TITLE
Share bindgen installations across Gradle modules

### DIFF
--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/UniffiPlugin.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/UniffiPlugin.kt
@@ -41,7 +41,7 @@ class UniffiPlugin : Plugin<Project> {
     private companion object {
         private const val PREFIX: String = "uniffi"
 
-        /** The path where the bindgen binary will be installed relative to the project */
+        /** The shared path where bindgen binaries are installed relative to the root project. */
         private const val BINDGEN_INSTALL_PATH: String = "$PREFIX/bindgen"
 
         /** The path where the bindgen binary will be built relative to the *root* project */
@@ -98,6 +98,7 @@ class UniffiPlugin : Plugin<Project> {
         val installBindgenTask = project.registerInstallBindgenTask()
         val buildLibraryForBindingsTask = project.registerBuildLibraryForBindingsTask(cargoInfo)
         val buildBindingsTask = project.registerBuildBindingsTask(
+            installBindgenTask = installBindgenTask,
             bindgenBin = installBindgenTask.flatMap { it.bindgenBinPath },
             libraryForBindings = buildLibraryForBindingsTask.flatMap { it.dynamicLibraryFile },
             metadataJson = metadataJsonProvider,
@@ -268,17 +269,22 @@ class UniffiPlugin : Plugin<Project> {
     }
 
     /**
-     * Installs the bindgen for the project in the relative path [BINDGEN_INSTALL_PATH]. Sets the
-     * `CARGO_TARGET_DIR` to the path [BINDGEN_BUILD_PATH] relative to the **root project**, so that
-     * cargo can reuse the build files if the root project has multiple subprojects where the
-     * bindgen needs to be installed to.
+     * Installs bindgen into a source-keyed directory under the root project's build directory.
+     * This lets modules using the same bindgen share both the executable and Cargo's build files.
      */
     private fun Project.registerInstallBindgenTask(): TaskProvider<InstallBindgenTask> =
         project.tasks.register(Tasks.INSTALL_BINDGEN, InstallBindgenTask::class.java) { task ->
             task.source.set(uniffiExtension.bindgenSource)
-            task.bindgenInstallPath.set(project.layout.buildDirectory.dir(BINDGEN_INSTALL_PATH))
+            val bindgenSource = uniffiExtension.bindgenSource
+            task.bindgenInstallPath.set(
+                project.rootProject.layout.buildDirectory.dir(
+                    bindgenSource.map { source -> "$BINDGEN_INSTALL_PATH/${source.cacheKey}" }
+                )
+            )
             task.bindgenBuildPath.set(
-                project.rootProject.layout.buildDirectory.dir(BINDGEN_BUILD_PATH)
+                project.rootProject.layout.buildDirectory.dir(
+                    bindgenSource.map { source -> "$BINDGEN_BUILD_PATH/${source.cacheKey}" }
+                )
             )
             task.defaultBindgenBinName.set(Constants.BINDGEN_BIN_NAME)
         }
@@ -312,11 +318,16 @@ class UniffiPlugin : Plugin<Project> {
      * generated from a UDL file.
      */
     private fun Project.registerBuildBindingsTask(
+        installBindgenTask: TaskProvider<InstallBindgenTask>,
         bindgenBin: Provider<RegularFile>,
         libraryForBindings: Provider<RegularFile>,
         metadataJson: Provider<String>,
     ): TaskProvider<BuildBindingsTask> =
         tasks.register(Tasks.BUILD_BINDINGS, BuildBindingsTask::class.java) { task ->
+            // bindgen is installed into a shared, source-keyed directory. Its install task is
+            // deliberately not a Gradle output (the executable is reused across module tasks),
+            // so retain the dependency explicitly rather than relying on output inference.
+            task.dependsOn(installBindgenTask)
             task.packageDirectory.set(cargoExtension.packageDirectory)
             task.cargoMetadata.set(metadataJson)
             task.generateBindingsForExternalCrates.set(

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/services/CargoMetadataService.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/services/CargoMetadataService.kt
@@ -1,6 +1,7 @@
 package ch.ubique.uniffi.plugin.services
 
 import ch.ubique.uniffi.plugin.utils.RustLocator
+import ch.ubique.uniffi.plugin.utils.withCargoPackageCacheLock
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
@@ -23,10 +24,12 @@ abstract class CargoMetadataService : ValueSource<String, CargoMetadataParams> {
     override fun obtain(): String {
         val stdout = ByteArrayOutputStream()
         val cargoCommand = RustLocator.findRustExecutable("cargo")
-        execOperations.exec { spec ->
-            spec.commandLine(cargoCommand.path, "metadata", "--format-version", "1")
-            spec.workingDir = parameters.packageDirectory.asFile.get()
-            spec.standardOutput = stdout
+        withCargoPackageCacheLock {
+            execOperations.exec { spec ->
+                spec.commandLine(cargoCommand.path, "metadata", "--format-version", "1")
+                spec.workingDir = parameters.packageDirectory.asFile.get()
+                spec.standardOutput = stdout
+            }
         }
 
         return String(stdout.toByteArray(), Charset.defaultCharset())

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/tasks/CargoBuildTask.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/tasks/CargoBuildTask.kt
@@ -3,6 +3,7 @@ package ch.ubique.uniffi.plugin.tasks
 import ch.ubique.uniffi.plugin.model.BuildTarget
 import ch.ubique.uniffi.plugin.model.CrateType
 import ch.ubique.uniffi.plugin.utils.CargoRunner
+import ch.ubique.uniffi.plugin.utils.withCargoTargetLock
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.Directory
@@ -25,7 +26,6 @@ import org.gradle.work.DisableCachingByDefault
 
 @DisableCachingByDefault(because = "Cargo caches incrementally, and the rust toolchain is not a declared input")
 abstract class CargoBuildTask : DefaultTask() {
-
     @get:Internal
     abstract val packageDirectory: DirectoryProperty
 
@@ -126,34 +126,36 @@ abstract class CargoBuildTask : DefaultTask() {
 
     @TaskAction
     fun build() {
-        CargoRunner(logger, useCross = useCross.get()) {
-            argument("rustc")
-            argument("--lib")
-            if (rustTarget.isPresent) {
-                argument("--target")
-                argument(rustTarget.get().rustTriple)
-            }
-            argument("--package")
-            argument(packageName.get())
+        withCargoTargetLock(cargoTargetDirectory.asFile.get()) {
+            CargoRunner(logger, useCross = useCross.get()) {
+                argument("rustc")
+                argument("--lib")
+                if (rustTarget.isPresent) {
+                    argument("--target")
+                    argument(rustTarget.get().rustTriple)
+                }
+                argument("--package")
+                argument(packageName.get())
 
-            if (release.get()) {
-                argument("--release")
-            }
+                if (release.get()) {
+                    argument("--release")
+                }
 
-            if (crateTypes.isPresent && crateTypes.get().isNotEmpty()) {
-                argument("--crate-type")
-                argument(crateTypes.get().sortedBy { it.toString() }.joinToString(","))
-            }
+                if (crateTypes.isPresent && crateTypes.get().isNotEmpty()) {
+                    argument("--crate-type")
+                    argument(crateTypes.get().sortedBy { it.toString() }.joinToString(","))
+                }
 
-            workdir(packageDirectory.asFile.get())
+                workdir(packageDirectory.asFile.get())
 
-            env("CARGO_TARGET_DIR", cargoTargetDirectory.get().asFile.absolutePath)
-            rustcWrapper.orNull?.let { env("RUSTC_WRAPPER", it) }
-            rustcWorkspaceWrapper.orNull?.let { env("RUSTC_WORKSPACE_WRAPPER", it) }
+                env("CARGO_TARGET_DIR", cargoTargetDirectory.get().asFile.absolutePath)
+                rustcWrapper.orNull?.let { env("RUSTC_WRAPPER", it) }
+                rustcWorkspaceWrapper.orNull?.let { env("RUSTC_WORKSPACE_WRAPPER", it) }
 
-            additionalEnvironment.get().forEach { (key, value) ->
-                env(key, value)
-            }
-        }.run()
+                additionalEnvironment.get().forEach { (key, value) ->
+                    env(key, value)
+                }
+            }.run()
+        }
     }
 }

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/tasks/GenerateDefFileTask.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/tasks/GenerateDefFileTask.kt
@@ -1,6 +1,7 @@
 package ch.ubique.uniffi.plugin.tasks
 
 import ch.ubique.uniffi.plugin.utils.CargoRunner
+import ch.ubique.uniffi.plugin.utils.withCargoTargetLock
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
@@ -108,28 +109,30 @@ abstract class GenerateDefFileTask : DefaultTask() {
     }
 
     private fun getLinkerOpts(): String? {
-        val output = CargoRunner(logger, useCross = useCross.get()) {
-            argument("rustc")
-            argument("--lib")
-            argument("--target")
-            argument(targetString.get())
-            argument("--crate-type")
-            argument("staticlib")
-            argument("--")
-            argument("--print")
-            argument("native-static-libs")
+        val output = withCargoTargetLock(cargoTargetDirectory.asFile.get()) {
+            CargoRunner(logger, useCross = useCross.get()) {
+                argument("rustc")
+                argument("--lib")
+                argument("--target")
+                argument(targetString.get())
+                argument("--crate-type")
+                argument("staticlib")
+                argument("--")
+                argument("--print")
+                argument("native-static-libs")
 
-            workdir(packageDirectory.asFile.get())
+                workdir(packageDirectory.asFile.get())
 
-            env("CARGO_TARGET_DIR", cargoTargetDirectory.get().asFile.absolutePath)
-            rustcWrapper.orNull?.let { env("RUSTC_WRAPPER", it) }
-            rustcWorkspaceWrapper.orNull?.let { env("RUSTC_WORKSPACE_WRAPPER", it) }
-            additionalEnvironment.get().forEach { (key, value) ->
-                env(key, value)
-            }
+                env("CARGO_TARGET_DIR", cargoTargetDirectory.get().asFile.absolutePath)
+                rustcWrapper.orNull?.let { env("RUSTC_WRAPPER", it) }
+                rustcWorkspaceWrapper.orNull?.let { env("RUSTC_WORKSPACE_WRAPPER", it) }
+                additionalEnvironment.get().forEach { (key, value) ->
+                    env(key, value)
+                }
 
-            redirectErrorStream(true)
-        }.run()
+                redirectErrorStream(true)
+            }.run()
+        }
 
         val linkerFlag = output.split('\n')
             .map { it.trim().substringAfter("note: native-static-libs: ", "") }

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/tasks/InstallBindgenTask.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/tasks/InstallBindgenTask.kt
@@ -2,6 +2,7 @@ package ch.ubique.uniffi.plugin.tasks
 
 import ch.ubique.uniffi.plugin.utils.BindgenSource
 import ch.ubique.uniffi.plugin.utils.CargoRunner
+import ch.ubique.uniffi.plugin.utils.withCargoTargetLock
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
@@ -9,7 +10,6 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 
@@ -21,7 +21,7 @@ abstract class InstallBindgenTask : DefaultTask() {
     @get:Internal
     abstract val defaultBindgenBinName: Property<String>
 
-    @get:OutputDirectory
+    @get:Internal
     abstract val bindgenInstallPath: DirectoryProperty
 
     @get:Internal
@@ -32,67 +32,77 @@ abstract class InstallBindgenTask : DefaultTask() {
                 .map { "bin/$it" }
         )
 
-    @get:OutputDirectory
+    @get:Internal
     abstract val bindgenBuildPath: DirectoryProperty
 
     @TaskAction
     fun action() {
-        CargoRunner(logger) {
-            argument("install")
-            argument("--root")
-            argument(bindgenInstallPath.asFile.get().path)
-            argument("--force")
+        val bindgenBinary = bindgenBinPath.get().asFile
+        withCargoTargetLock(bindgenBuildPath.asFile.get()) {
+            // Recheck after acquiring the lock: sibling module tasks may have observed a missing
+            // executable at the same time and then waited for the first installation to finish.
+            if (bindgenBinary.isFile) {
+                logger.info("Reusing bindgen at $bindgenBinary")
+                return@withCargoTargetLock
+            }
 
-            val source = source.get()
-            when (source) {
-                is BindgenSource.Path -> {
-                    argument("--path")
-                    argument(source.path)
+            CargoRunner(logger) {
+                argument("install")
+                argument("--root")
+                argument(bindgenInstallPath.asFile.get().path)
+                argument("--force")
 
-                    if (source.features.isNotEmpty()) {
-                        argument("--features")
-                        argument(source.features.joinToString(","))
+                val source = source.get()
+                when (source) {
+                    is BindgenSource.Path -> {
+                        argument("--path")
+                        argument(source.path)
+
+                        if (source.features.isNotEmpty()) {
+                            argument("--features")
+                            argument(source.features.joinToString(","))
+                        }
+                    }
+
+                    is BindgenSource.Git -> {
+                        argument("--git")
+                        argument(source.repository)
+                        when (source.commit) {
+                            is BindgenSource.Git.Commit.Branch -> {
+                                argument("--branch")
+                                argument(source.commit.branch)
+                            }
+
+                            is BindgenSource.Git.Commit.Tag -> {
+                                argument("--tag")
+                                argument(source.commit.tag)
+                            }
+
+                            is BindgenSource.Git.Commit.Revision -> {
+                                argument("--rev")
+                                argument(source.commit.revision)
+                            }
+
+                            else -> {}
+                        }
+                    }
+
+                    is BindgenSource.Registry -> {
+                        argument("${source.packageName}@${source.version}")
                     }
                 }
 
-                is BindgenSource.Git -> {
-                    argument("--git")
-                    argument(source.repository)
-                    when (source.commit) {
-                        is BindgenSource.Git.Commit.Branch -> {
-                            argument("--branch")
-                            argument(source.commit.branch)
-                        }
-
-                        is BindgenSource.Git.Commit.Tag -> {
-                            argument("--tag")
-                            argument(source.commit.tag)
-                        }
-
-                        is BindgenSource.Git.Commit.Revision -> {
-                            argument("--rev")
-                            argument(source.commit.revision)
-                        }
-
-                        else -> {}
-                    }
+                source.bindgenName?.let {
+                    argument("--bin")
+                    argument(it)
                 }
 
-                is BindgenSource.Registry -> {
-                    argument("${source.packageName}@${source.version}")
+                source.packageName?.let {
+                    argument(it)
                 }
-            }
 
-            source.bindgenName?.let {
-                argument("--bin")
-                argument(it)
-            }
-
-            source.packageName?.let {
-                argument(it)
-            }
-
-            env("CARGO_TARGET_DIR", bindgenBuildPath.asFile.get().path)
-        }.run()
+                env("CARGO_TARGET_DIR", bindgenBuildPath.asFile.get().path)
+            }.run()
+        }
     }
 }

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/utils/BindgenSource.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/utils/BindgenSource.kt
@@ -1,11 +1,26 @@
 package ch.ubique.uniffi.plugin.utils
 
 import java.io.Serializable
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 
 sealed class BindgenSource(
     open val bindgenName: String?,
     open val packageName: String?,
 ) : Serializable {
+    /**
+     * A stable, filesystem-safe identity for the bindgen installation.
+     *
+     * Multiple projects in one Gradle build commonly use the same bindgen source. The identity
+     * lets the plugin share the installation without allowing two different sources to overwrite
+     * one another.
+     */
+    val cacheKey: String
+        get() = MessageDigest.getInstance("SHA-256")
+            .digest(toString().toByteArray(StandardCharsets.UTF_8))
+            .take(12)
+            .joinToString("") { byte -> "%02x".format(byte) }
+
     data class Registry(
         override val packageName: String,
         val version: String,

--- a/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/utils/CargoRunner.kt
+++ b/build-logic/gradle-plugin/src/main/kotlin/ch/ubique/uniffi/plugin/utils/CargoRunner.kt
@@ -137,3 +137,28 @@ fun <T> withGlobalFileLock(lockFile: File, action: () -> T): T {
         lock.use { return action() }
     }
 }
+
+/**
+ * Cargo's package cache is shared by all Cargo processes for a user. Coordinate plugin-managed
+ * Cargo commands across Gradle projects as well as within one project, including CI matrix jobs
+ * that happen to share a runner.
+ */
+fun <T> withCargoPackageCacheLock(action: () -> T): T {
+    val lockFile = File(
+        System.getProperty("java.io.tmpdir"),
+        "ch.ubique.uniffi.cargo-package-cache.lock",
+    )
+    return withGlobalFileLock(lockFile, action)
+}
+
+/**
+ * Cargo serializes access to a target directory internally. Use a plugin-owned lock as well so
+ * several Gradle projects do not all sit inside Cargo waiting for the same lock.
+ */
+fun <T> withCargoTargetLock(targetDirectory: File, action: () -> T): T {
+    val lockFile = targetDirectory.resolve(".uniffi-cargo.lock")
+    lockFile.parentFile.mkdirs()
+    return withCargoPackageCacheLock {
+        withGlobalFileLock(lockFile, action)
+    }
+}


### PR DESCRIPTION
## Summary

- Share UniFFI bindgen installations in the root build directory, keyed by bindgen source.
- Reuse an existing executable instead of running `cargo install --force` once per module.
- Coordinate plugin-managed Cargo processes with a package-cache lock and per-target-directory lock.
- Keep `buildBindings` explicitly dependent on its module install task while avoiding shared-output validation errors.

## Reproduction and verification

The three-module multi-module fixture reproduced repeated Cargo package-cache/build-directory lock messages and installed the same bindgen three times.

With this branch:

- The fixture uses one shared bindgen installation and all three modules log reuse.
- `:build-logic:gradle-plugin:check` passes.
- The full Kapun `buildBindings` graph succeeds; all 15 module install tasks use the shared root path.
- Kapun iOS arm64 def-file generation succeeds against a locally published copy of this plugin.

The `appleMainResolvableDependenciesMetadata` warning is emitted by the KMP dependency-resolution stack, not by the UniFFI plugin task code, and remains a separate investigation.
